### PR TITLE
add StatementRefs. Closes #39 and #99.

### DIFF
--- a/xapi-profiles-spec.md
+++ b/xapi-profiles-spec.md
@@ -162,8 +162,8 @@ Name | Values
 `contextOtherActivityType` | *Optional*. Array of contextActivities other activity type IRIs
 `contextCategoryActivityType` | *Optional*. Array of contextActivities category activity type IRIs
 `attachmentUsageType` | *Optional*. Array of attachment usage type IRIs
-`objectStatementRefTemplate` | *Optional*. A Statement Template identifier from this profile version. May not be used with `objectActivityType`. If specified, the Statement object must be a StatementRef and the Learning Record Provider MUST make it the UUID of a Statement matching the specified Statement Template.
-`contextStatementRefTemplate`. *Optional*. A Statement Template identifier from this profile version. If specified, the Statement context statement property must be a StatementRef and the Learning Record Provider MUST make it the UUID of a Statement matching the specified Statement Template.
+`objectStatementRefTemplate` | *Optional*. An array of Statement Template identifiers from this profile version. May not be used with `objectActivityType`. If specified, the Statement object must be a StatementRef and the Learning Record Provider MUST make it the UUID of a Statement matching at least one of the specified Statement Templates.
+`contextStatementRefTemplate`. *Optional*. An array of Statement Template identifiers from this profile version. If specified, the Statement context statement property must be a StatementRef and the Learning Record Provider MUST make it the UUID of a Statement matching at least one of the specified Statement Templates.
 `rules` | Array of Statement Template Rules
 
 


### PR DESCRIPTION
This makes it possible to, for example, have a StatementTemplate for "reviewing accomplishment" statements where the actor reviews an object agent, then have another StatementTemplate for "has been judged competent in" statements that must have a context statement StatementRef pointing at "reviewing accomplishment" statements.

Also includes a variety of other clarifying language related to this change, some of which should be reviewed for inclusion if this PR is rejected.