### PR TITLE
Updated README & Authored Profiles Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ companion to xAPI, and is divided into three documents:
 The current version of the specification is
 [1.0](https://github.com/DataInteroperability/xapi-profiles).
 
+## Authored Profiles
+
+ADL maintains a [public repository of authored xAPI profiles](https://github.com/adlnet/xapi-authored-profiles) based on this specification and processes provided by ADL's vocabulary and profile index, [http://xapi.vocab.pub](http://xapi.vocab.pub). 
+
 ## What to do if the spec is unclear
 
 If when implementing the specification you find something is unclear or
@@ -34,14 +38,10 @@ you do not already have one in order to raise and comment on issues.
 
 You can discuss any issues before or after raising them on the
 [xAPI Profiles Google Group](https://groups.google.com/a/adlnet.gov/forum/#!forum/xapi-spec)
-and at ADL's
-[weekly specification calls](https://attendee.gotowebinar.com/register/5526804432322315009).
+
 
 ## How you can contribute
 
 You'll need to [sign up for a GitHub account](https://github.com/signup/free) if
 you do not already have one in order to contribute to the specification.
 
-ADL's xAPI Spec Working Group meets
-the first, second, and third Wednesdays of each month. Instructions to register for these online meetings and
-more information related to ADL's xAPI work can be found at [https://www.adlnet.gov/xAPI](https://www.adlnet.gov/xAPI)

--- a/xapi-profiles-communication.md
+++ b/xapi-profiles-communication.md
@@ -46,14 +46,18 @@ are validated against Statements. It also describes a “Profile Server” to ma
 to manage and answer questions about Profiles from a centralized location, including
 implementing the algorithms.
 
+## Authored Profiles
+
+ADL maintains a [centralized public repository of authored xAPI profiles](https://github.com/adlnet/xapi-authored-profiles) based on this specification. The repository of profiles are imported and synchronized regularly into ADL's Profile Server, [http://xapi.vocab.pub](http://xapi.vocab.pub). 
+
 <a name="prof-server"></a>
 ## 1.0 Profile Server
 
 A Profile Server manages xAPI Profiles from a centralized location. [An RDF triple store](https://en.wikipedia.org/wiki/Triplestore) is responsible for the storage of Profiles.
 A Profile Server will allow administrators to add Profiles by their contents or by URI to the Profile Server
 
-A Profile Server will host a SPARQL endpoint containing the RDF information from the
-contained Profiles at the path /sparql. This enables xAPI Profiles to be queried. SPARQL
+ADL's Profile Server will host a SPARQL endpoint containing the RDF information from the
+contained Profiles at the path /sparql (e.g., http://xapi.vocab.pub/sparql). This enables xAPI Profiles to be queried. SPARQL
 servers have the ability to divide information into multiple datasets, or graphs, and
 offer separate querying on them. One of these is the default graph, which is queried
 when no other graph is specified. The default graph at this SPARQL endpoint will


### PR DESCRIPTION
Updated readme to remove meeting info since this group is no longer meeting regularly. Also added info links regarding the centralized repo for authored profiles.