### PR TITLE
Update references and clarify JSONPath constraints

### DIFF
--- a/xapi-profiles-about.md
+++ b/xapi-profiles-about.md
@@ -243,7 +243,7 @@ even if there no requirement in a given area.
 
 <a name="jsonld"></a>**JSON-LD**: [JSON-LD](https://json-ld.org) turns JSON into Linked Data, making it easy to use with Linked Data tools and integrate with other datasets.
 
-<a name="jsonpath"></a>**JSONPath**: [JSONPath](http://goessner.net/articles/JsonPath/index.html#e2) provides a way to address parts of JSON documents using a `JSONPath expression`.
+<a name="jsonpath"></a>**JSONPath**: [JSONPath](https://datatracker.ietf.org/doc/draft-ietf-jsonpath-base/05/) provides a way to address parts of JSON documents using a `JSONPath expression`. This specification proposes some [constraints](./xapi-profiles-structure.md#jsonpath-constraints) to the possible JSONPath expressions.
 
 <a name="languagemap"></a>**Language Map**: A Language Map expresses multiple language-specific values at once. While used in the xAPI specification essentially identically, the controlling specification is [JSON-LD Language Maps](https://www.w3.org/TR/json-ld/#language-maps).
 

--- a/xapi-profiles-communication.md
+++ b/xapi-profiles-communication.md
@@ -273,7 +273,7 @@ function follows_rule(statement, rule):
 function apply_jsonpath(statement, path):
     The definition of this is beyond the scope of this document, but it follows
     the JSONPath specification as constrained by the requirements in this
-    specification. If a single value is found in the Statement matching the
+    specification (xapi-profiles-structure.md#jsonpath-constraints). If a single value is found in the Statement matching the
     path, it is returned in an array (even if the single value is already an array). If
     multiple values are found, they are returned in an array.
     If no values are found, an empty array is returned.

--- a/xapi-profiles-structure.md
+++ b/xapi-profiles-structure.md
@@ -509,10 +509,13 @@ A Profile Validator validating Statements MUST validate the Statement Template R
 
 When validating a Statement for Statement Template Rules, `contextActivities` normalization MUST have already been performed as described in the Experience API specification. That is, singleton objects MUST be replaced by arrays of length one.
 
-The syntax and behavior of JSONPath is described at http://goessner.net/articles/JsonPath/index.html#e2. In addition, the following requirements, clarifications, and additions apply:
-* Filter and script expressions MUST NOT be used.
+<a name="jsonpath-constrains"></a>
+#### JSONPath Constraints
+
+The syntax and behavior of JSONPath is described at https://datatracker.ietf.org/doc/draft-ietf-jsonpath-base/05/. In addition, the following requirements, clarifications, and additions apply:
+* Filter (`?(<exp>)`) and script (`(<exp>)`) expressions MUST NOT be used.
 * The union operator (a comma) may be used inside array or child expressions, so the result is the union on each expression being used separately.
-* The legal values in an array or child expression are: strings (child expressions), non-negative integers (array expressions), the star character `*` representing all children/members, and unions of these as described above.
+* The legal values in an array or child expression are: strings (child expressions), non-negative integers (array expressions), the star character `*` representing all children/members, and unions of these as described above. The array slice operator MUST NOT be used.
 * Any two or more legal JSONPath expressions, joined together by the pipe character `|`, optionally with whitespace around the pipe, are also considered a legal JSONPath expression. The value of this expression is all the values returned by each expression individually, flattened (that is, if one expression returns N values and another returns a single value, the combination returns N+1 values, not two values).
 
 #### Example


### PR DESCRIPTION
This PR, tries to address #257 by:
- Updating references to JSONPath specification document that is currently under the development of the [IETF JSONPath WG](https://datatracker.ietf.org/wg/jsonpath/about/). The spec points to the last version of the draft that is currently published. Although the current draft deviates from the original JSONPath spec, it is mostly related to filter and scripting expressions that the xAPI profiles spec forbids. 
- Adds some cross references between the documents to help the reader.

Fixes #257