### PR TITLE
xAPI Profiles 2.0 / Alignment to xAPI 2.0: Statement Template Rule values / comparison

### DIFF
--- a/xapi-profiles-communication.md
+++ b/xapi-profiles-communication.md
@@ -176,9 +176,11 @@ function described in pseudocode below with the Statement and all the Statement 
 from the Profile. This function returns an outcome and an array of Statement Templates. To
 interpret the results, consult the table after the algorithm definition.
 
-* Comparison between `values` parsed from the Statement and the `any`, `all` and `none` values
-MUST be based on the data comparison requirements defined within the profile's xAPI Version (`xAPIVersion` property).
-        * when `xAPIVersion` profile property is not specified, the data comparison requirements within the most recent version of xAPI MUST be used.
+Comparison between `values` parsed from the Statement and the `any`, `all` and `none` values
+MUST be based on the data comparison requirements defined within the profile's xAPI Version.
+* xAPI data comparison is based off of the optional `xAPIVersion` Profile value.
+    * when `xAPIVersion` is not specified, data MUST be compared via constraints defined within the most recent version of xAPI
+    * when `xAPIVersion` is specified, data MUST be compared via constraints dsefined within the specified version of xAPI
 
 ```
 function validates(statement, templates):

--- a/xapi-profiles-communication.md
+++ b/xapi-profiles-communication.md
@@ -177,9 +177,9 @@ from the Profile. This function returns an outcome and an array of Statement Tem
 interpret the results, consult the table after the algorithm definition.
 
 Comparison between `values` parsed from the Statement and the `any`, `all` and `none` values
-MUST be based on the data comparison requirements defined within the profile's xAPI Version.
-* xAPI data comparison is based off of the optional `xAPIVersion` Profile value.
-    * when `xAPIVersion` is not specified, data MUST be compared via constraints defined within the most recent version of xAPI
+MUST be based on the data comparison requirements defined within the profile's `xAPIVersion`.
+* xAPI data comparison is based on of the optional `xAPIVersion` Profile value.
+    * when `xAPIVersion` is not specified, data MUST be compared via constraints defined within the version 2.0 of xAPI
     * when `xAPIVersion` is specified, data MUST be compared via constraints dsefined within the specified version of xAPI
 
 ```

--- a/xapi-profiles-communication.md
+++ b/xapi-profiles-communication.md
@@ -6,7 +6,7 @@
       *  2.1. [MUST / SHOULD / MAY](./xapi-profiles-about.md#def-must-should-may)
       *  2.2. [Guidelines for Interpreting Descriptive Text and Tables](./xapi-profiles-about.md#interpret-text-table)
    *  3.0. [Definitions](./xapi-profiles-about.md#definitions)
-* Part Two: [xAPI Profiles Document Structure Specification](./xapi-profiles-structure.md#part-two)  
+* Part Two: [xAPI Profiles Document Structure Specification](./xapi-profiles-structure.md#part-two)
    *  1.0.  [Reference Specifications](./xapi-profiles-structure.md#ref-spec)
    *  2.0.  [Technical Foundations](./xapi-profiles-structure.md#tech-foundations)
    *  3.0.  [Structure](./xapi-profiles-structure.md#structure)
@@ -24,7 +24,7 @@
       *  8.1.  [Statement Template Rules](./xapi-profiles-structure.md#statement-template-rules)
    *  9.0.  [Patterns](./xapi-profiles-structure.md#patterns)
    *  10.0. [The Context](./xapi-profiles-structure.md#context)
-* Part Three: [xAPI Profiles Communication and Processing Specification](./xapi-profiles-communication.md#part-three)  
+* Part Three: [xAPI Profiles Communication and Processing Specification](./xapi-profiles-communication.md#part-three)
    * 1.0. [Profile Server](./xapi-profiles-communication.md#prof-server)
       * 1.1. [Profile Versions](./xapi-profiles-communication.md#prof-versions)
       * 1.2. [Best Practices](./xapi-profiles-communication.md#best-practices)
@@ -48,7 +48,7 @@ implementing the algorithms.
 
 ## Authored Profiles
 
-ADL maintains a [centralized public repository of authored xAPI profiles](https://github.com/adlnet/xapi-authored-profiles) based on this specification. The repository of profiles are imported and synchronized regularly into ADL's Profile Server, [http://xapi.vocab.pub](http://xapi.vocab.pub). 
+ADL maintains a [centralized public repository of authored xAPI profiles](https://github.com/adlnet/xapi-authored-profiles) based on this specification. The repository of profiles are imported and synchronized regularly into ADL's Profile Server, [http://xapi.vocab.pub](http://xapi.vocab.pub).
 
 <a name="prof-server"></a>
 ## 1.0 Profile Server
@@ -142,7 +142,7 @@ select
     ?prefLabel,
     ?definition
 where {
-    (?concept a xapi:Verb || ?concept a xapi:ActivityType) .                
+    (?concept a xapi:Verb || ?concept a xapi:ActivityType) .
     ?concept skos:inScheme <http://example.org/profiles/sports> ;
              skos:prefLabel ?prefLabel ;
              skos:definition ?definition .
@@ -175,6 +175,10 @@ To validate a Statement against the Statement Templates of a Profile, call the `
 function described in pseudocode below with the Statement and all the Statement Templates
 from the Profile. This function returns an outcome and an array of Statement Templates. To
 interpret the results, consult the table after the algorithm definition.
+
+* Comparison between `values` parsed from the Statement and the `any`, `all` and `none` values
+MUST be based on the data comparison requirements defined within the profile's xAPI Version (`xAPIVersion` property).
+        * when `xAPIVersion` profile property is not specified, the data comparison requirements within the most recent version of xAPI MUST be used.
 
 ```
 function validates(statement, templates):

--- a/xapi-profiles-structure.md
+++ b/xapi-profiles-structure.md
@@ -496,8 +496,8 @@ A Profile Author MUST include the keys of any non-primitive objects in `any`, `a
 
 A Profile Author MUST ensure that values included within `any`, `all`, and `none` are valid xAPI values based on a Rule's `location` and `selector`.
 * xAPI data conformance is based off of the optional `xAPIVersion` Profile value.
-    * When `xAPIVersion` is not specified, xAPI data should be validated via the most recent version of xAPI
-    * When `xAPIVersion` is specified, xAPI data should be validated against the specified version of xAPI
+    * When `xAPIVersion` is not specified, xAPI data MUST be validated via the most recent version of xAPI
+    * When `xAPIVersion` is specified, xAPI data MUST be validated against the specified version of xAPI
 
 A Learning Record Provider authoring a Statement for the Statement Template including this Statement Template Rule:
 * MUST include at least one matchable value if `presence` is `included`

--- a/xapi-profiles-structure.md
+++ b/xapi-profiles-structure.md
@@ -6,7 +6,7 @@
       *  2.1. [MUST / SHOULD / MAY](./xapi-profiles-about.md#def-must-should-may)
       *  2.2. [Guidelines for Interpreting Descriptive Text and Tables](./xapi-profiles-about.md#interpret-text-table)
    *  3.0. [Definitions](./xapi-profiles-about.md#definitions)
-* Part Two: [xAPI Profiles Document Structure Specification](./xapi-profiles-structure.md#part-two)  
+* Part Two: [xAPI Profiles Document Structure Specification](./xapi-profiles-structure.md#part-two)
    *  1.0.  [Reference Specifications](./xapi-profiles-structure.md#ref-spec)
    *  2.0.  [Technical Foundations](./xapi-profiles-structure.md#tech-foundations)
    *  3.0.  [Structure](./xapi-profiles-structure.md#structure)
@@ -24,7 +24,7 @@
       *  8.1.  [Statement Template Rules](./xapi-profiles-structure.md#statement-template-rules)
    *  9.0.  [Patterns](./xapi-profiles-structure.md#patterns)
    *  10.0. [The Context](./xapi-profiles-structure.md#context)
-* Part Three: [xAPI Profiles Communication and Processing Specification](./xapi-profiles-communication.md#part-three)  
+* Part Three: [xAPI Profiles Communication and Processing Specification](./xapi-profiles-communication.md#part-three)
    * 1.0. [Profile Server](./xapi-profiles-communication.md#prof-server)
       * 1.1. [Profile Versions](./xapi-profiles-communication.md#prof-versions)
       * 1.2. [Best Practices](./xapi-profiles-communication.md#best-practices)
@@ -494,6 +494,11 @@ A Statement Template Rule MUST include one or more of `presence`, `any`, `all`, 
 
 A Profile Author MUST include the keys of any non-primitive objects in `any`, `all`, and `none` in additional `@context` beyond the ones provided by this specification.
 
+A Profile Author MUST ensure that values included within `any`, `all`, and `none` are valid xAPI values based on a Rule's `location` and `selector`.
+* xAPI data conformance is based off of the optional `xAPIVersion` Profile value.
+    * When `xAPIVersion` is not specified, xAPI data should be validated via the most recent version of xAPI
+    * When `xAPIVersion` is specified, xAPI data should be validated against the specified version of xAPI
+
 A Learning Record Provider authoring a Statement for the Statement Template including this Statement Template Rule:
 * MUST include at least one matchable value if `presence` is `included`
 * MUST NOT include any unmatchable values if `presence` is `included`
@@ -505,6 +510,8 @@ A Learning Record Provider authoring a Statement for the Statement Template incl
     * MUST NOT, if `none` is provided, include any values in `none` as matchable values
 
 A Profile Validator validating Statements MUST validate the Statement Template Rule requirements for Learning Record Providers are followed. See the Communication document for further details on how to do so.
+* Comparison between matchable values and `any`, `all` and `none` values MUST be based on the data comparison requirements defined within the xAPI Version set as the `xAPIVersion` profile property.
+    * when `xAPIVersion` profile property is not specified, the data comparison requirements within the most recent version of xAPI MUST be used.
 
 
 When validating a Statement for Statement Template Rules, `contextActivities` normalization MUST have already been performed as described in the Experience API specification. That is, singleton objects MUST be replaced by arrays of length one.


### PR DESCRIPTION
Data Validation / Comparison based on new `xAPIVersion` property
- `xAPIVersion` added within https://github.com/adlnet/xapi-profiles/pull/274 to address https://github.com/adlnet/xapi-profiles/issues/267
- This PR addresses https://github.com/adlnet/xapi-profiles/issues/268

This PR has been migrated and updated from https://github.com/FeLungs/xapi-profiles/pull/11. See discussion there