### PR TITLE
xAPI Profiles 2.0 / Alignment to xAPI 2.0: timestamp clarifications

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,9 +1,0 @@
-Filing an issue about the **xAPI Profiles** specification? Please include the following
-
-- [ ] Which part/parts of the specification are at issue?
-
-- [ ] What is your understanding of what the spec means in these parts?
-
-- [ ] Related to your implementation, what's the use case you're trying to achieve? What are the user stories you're trying to support?
-
-- [ ] How you would like the specification to be improved?

--- a/context/profile-context.jsonld
+++ b/context/profile-context.jsonld
@@ -66,7 +66,7 @@
         },
         "generatedAtTime": {
             "@id": "prov:generatedAtTime",
-            "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+            "@type": "https://www.w3.org/TR/xmlschema11-2/#dateTimeStamp"
         },
         "name": {
             "@id": "schemaorg:name"

--- a/xapi-profiles-about.md
+++ b/xapi-profiles-about.md
@@ -210,6 +210,7 @@ even if there no requirement in a given area.
 * [Statement Template](#statementtemplate)
 * [StatementRef](#statementref)
 * [Subregistration](#subregistration)
+* [Timestamp](#timestamp)
 * [Verb](#verb)
 * [xAPI Profile Processor Library](#library)
 
@@ -280,6 +281,8 @@ even if there no requirement in a given area.
 <a name="statementref"></a>**StatementRef**: An [Experience API Statement Reference](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#statement-references). Used for pointing at a second Statement from a first.
 
 <a name="subregistration"></a>**Subregistration**: When multiple Patterns are being followed within a registration, subregistration is an extension specific to this specification to distinguish between them.
+
+<a name="timestamp"></a>**Timestamp**: An instant of time (date and time) that also includes the time zone. This data type adheres to the [XSD 1.1 dateTimeStamp](https://www.w3.org/TR/xmlschema11-2/#dateTimeStamp) type definition. That is, a timestamp is either represented in Universal Coordinated Time (UTC) and uses the UTC timezone identifier 'Z' or includes a time offset from UTC.
 
 <a name="verb"></a>**Verb**: An [Experience API Verb](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#verb). This specification helps Profile Authors provide additional metadata about verbs they control.
 

--- a/xapi-profiles-communication.md
+++ b/xapi-profiles-communication.md
@@ -405,6 +405,11 @@ order insofar as that can be determined. If Statements are received in the same 
 are being checked upon receipt, within the batch Statements MUST be ordered first by timestamp,
 and if timestamps are the same, by order within the Statement array, with lower indices earlier.
 
+
+**Note:** As stated in section [Part One: About xAPI Profiles, section 3](./xapi-profiles-about.md#timestamp)
+timestamps adheres to the `xsd:dateTimeStamp` data type defined in XSD 1.1 which is either represented in
+Universal Coordinated Time (UTC) and uses the UTC timezone identifier 'Z' or includes a time offset from UTC.
+
 <a name="libraries"></a>
 ## 3.0 Libraries
 

--- a/xapi-profiles-structure.md
+++ b/xapi-profiles-structure.md
@@ -117,7 +117,7 @@ Property | Type | Description | Required
 -------- | ---- | ----------- | --------
 `id` | IRI | The IRI of the version ID | Required
 `wasRevisionOf` | Array | An array, usually of length one, of IRIs of all Profile versions this version was written as a revision of | Optional
-`generatedAtTime` | Timestamp | The date this version was created on | Required
+`generatedAtTime` | [Timestamp](./xapi-profiles-about.md#timestamp) | The date this version was created on | Required
 
 `wasRevisionOf` MUST be used with all versions that succeed other Profile versions.
 


### PR DESCRIPTION
PR for #269 

I couldn't find out the XSD schema for 1.1 so I changed the reference in [084ce900c](https://github.com/FeLungs/xapi-profiles/commit/89f6f640d0da62807393d1200f761dd240ddfdb9) to link the normative definition.  Could be https://www.w3.org/TR/owl-time/#time:inXSDDateTimeStamp another better option ?

This PR has been migrated from https://github.com/FeLungs/xapi-profiles/pull/15. Copying relevant discussion below.

**TODO**
- [ ] Decide proper schema definition to include as reference material.

> I found this xml schema which contains the [dateTimeStamp](https://www.w3.org/2009/XMLSchema/derived.nxsd) definition but I'm not sure if we link directly to that schema or not.
>
> Within the schema, the targetNamespace field is "http://www.w3.org/2001/XMLSchema" and after reading the [documentation](https://www.w3.org/TR/xmlschema-0/#UndeclaredTNS), I'm still not sure which is more correct; referencing the 2009 version or the 2001 version.
>
> - https://www.w3.org/2009/XMLSchema/derived.nxsd#dateTimeStamp
> - http://www.w3.org/2001/XMLSchema#dateTimeStamp 

> I'm not sure too. Reading [owl time](https://www.w3.org/TR/owl-time/#trs-clock-calendar) in the documentation they reference to the [XSD 1.1 normative reference (HTML document)](https://www.w3.org/TR/xmlschema11-2/#dateTimeStamp), but in the RDF representation seems that they use `http://www.w3.org/2001/XMLSchema#dateTimeStamp`
>
 ```
<owl:DatatypeProperty rdf:ID="inXSDDateTimeStamp">
    <skos:definition xml:lang="es">Posición de un instante, expresado utilizando xsd:dateTimeStamp.</skos:definition>
    <rdfs:label xml:lang="es">en fecha-sello de tiempo XSD</rdfs:label>
    <rdfs:comment xml:lang="es">Posición de un instante, expresado utilizando xsd:dateTimeStamp.</rdfs:comment>
    <skos:definition xml:lang="en">Position of an instant, expressed using xsd:dateTimeStamp</skos:definition>
    <rdfs:range>
      <rdf:Description rdf:about="http://www.w3.org/2001/XMLSchema#dateTimeStamp">
        <rdfs:label xml:lang="es">sello de tiempo</rdfs:label>
      </rdf:Description>
    </rdfs:range>
    <rdfs:label xml:lang="en">in XSD Date-Time-Stamp</rdfs:label>
    <rdfs:domain rdf:resource="#Instant"/>
    <rdfs:comment xml:lang="en">Position of an instant, expressed using xsd:dateTimeStamp</rdfs:comment>
  </owl:DatatypeProperty>
```